### PR TITLE
Add repair system for scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.3](https://github.com/hugobloem/stateful_scenes/compare/v1.7.2...v1.7.3) (2025-07-17)
+
+### 🚀 Features
+
+* add repair system to detect duplicate scene IDs and empty attributes
+
+
 ## [1.7.2](https://github.com/hugobloem/stateful_scenes/compare/v1.7.1...v1.7.2) (2025-07-05)
 
 

--- a/custom_components/stateful_scenes/__init__.py
+++ b/custom_components/stateful_scenes/__init__.py
@@ -22,6 +22,7 @@ from .const import (
 from .discovery import DiscoveryManager
 from .StatefulScenes import Hub, Scene
 from .helpers import async_cleanup_orphaned_entities
+from .repairs import async_register_repairs, check_for_repair_issues
 
 PLATFORMS: list[Platform] = [
     Platform.NUMBER,
@@ -44,6 +45,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             raise StatefulScenesYamlNotFound("Scenes file not specified.")
 
         scene_confs = await load_scenes_file(entry.data[CONF_SCENE_PATH])
+
+        await check_for_repair_issues(hass, scene_confs)
+        async_register_repairs(hass, entry.data[CONF_SCENE_PATH])
 
         hub = Hub(
             hass=hass,

--- a/custom_components/stateful_scenes/manifest.json
+++ b/custom_components/stateful_scenes/manifest.json
@@ -5,11 +5,14 @@
     "@hugobloem"
   ],
   "config_flow": true,
+  "dependencies": [
+    "repairs"
+  ],
   "documentation": "https://github.com/hugobloem/stateful_scenes",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/hugobloem/stateful_scenes/issues",
   "requirements": [
     "aiofiles"
   ],
-  "version": "1.7.2"
+  "version": "1.7.3"
 }

--- a/custom_components/stateful_scenes/repairs.py
+++ b/custom_components/stateful_scenes/repairs.py
@@ -1,0 +1,177 @@
+"""Repair issue detection and fix flows for Stateful Scenes."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from homeassistant.components.repairs import RepairsFlow, async_create_issue
+from homeassistant.components.repairs import async_register
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+REPAIR_DUPLICATE_SCENE_IDS = "duplicate_scene_ids"
+REPAIR_EMPTY_SCENE_ATTRIBUTES = "empty_scene_attributes"
+
+
+async def async_create_repair_issue_duplicate_ids(
+    hass: HomeAssistant, duplicate_scenes: list[dict[str, Any]]
+) -> None:
+    """Create a repair issue for duplicate scene IDs."""
+    scene_details = []
+    for info in duplicate_scenes:
+        scene_details.append(f"- {info['name']} (ID: {info['id']})")
+
+    scene_list = "\n".join(scene_details)
+    await async_create_issue(
+        hass,
+        DOMAIN,
+        REPAIR_DUPLICATE_SCENE_IDS,
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="duplicate_scene_ids",
+        translation_placeholders={
+            "scene_count": str(len(duplicate_scenes)),
+            "scene_list": scene_list,
+        },
+    )
+
+
+async def async_create_repair_issue_empty_attributes(
+    hass: HomeAssistant, affected_scenes: list[dict[str, Any]]
+) -> None:
+    """Create a repair issue for scenes with empty attributes."""
+    scene_details = []
+    for info in affected_scenes:
+        scene_details.append(
+            f"- {info['name']} has {info['empty_count']} empty attributes"
+        )
+
+    scene_list = "\n".join(scene_details)
+    await async_create_issue(
+        hass,
+        DOMAIN,
+        REPAIR_EMPTY_SCENE_ATTRIBUTES,
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="empty_scene_attributes",
+        translation_placeholders={
+            "scene_count": str(len(affected_scenes)),
+            "scene_list": scene_list,
+        },
+    )
+
+
+def detect_duplicate_scene_ids(scene_confs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Detect scenes with duplicate IDs."""
+    id_count: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for scene in scene_confs:
+        scene_id = scene.get("id", "")
+        scene_name = scene.get("name", "Unknown")
+        id_count[scene_id].append({"name": scene_name, "id": scene_id})
+
+    duplicates: list[dict[str, Any]] = []
+    for scenes in id_count.values():
+        if len(scenes) > 1:
+            duplicates.extend(scenes)
+
+    return duplicates
+
+
+def detect_empty_scene_attributes(scene_confs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Detect scenes with empty or None attributes."""
+    affected_scenes: list[dict[str, Any]] = []
+    for scene in scene_confs:
+        empty_count = 0
+        entities: dict[str, dict[str, Any]] = scene.get("entities", {})
+        for entity_data in entities.values():
+            for value in entity_data.values():
+                if value is None or value == "":
+                    empty_count += 1
+        if empty_count:
+            affected_scenes.append(
+                {
+                    "name": scene.get("name", "Unknown"),
+                    "id": scene.get("id", ""),
+                    "empty_count": empty_count,
+                }
+            )
+    return affected_scenes
+
+
+async def check_for_repair_issues(
+    hass: HomeAssistant, scene_confs: list[dict[str, Any]]
+) -> None:
+    """Create repair issues based on the scene configuration."""
+    duplicate_scenes = detect_duplicate_scene_ids(scene_confs)
+    if duplicate_scenes:
+        _LOGGER.warning(
+            "Found %d scenes with duplicate IDs", len(duplicate_scenes)
+        )
+        await async_create_repair_issue_duplicate_ids(hass, duplicate_scenes)
+
+    empty_attr_scenes = detect_empty_scene_attributes(scene_confs)
+    if empty_attr_scenes:
+        _LOGGER.warning(
+            "Found %d scenes with empty attributes", len(empty_attr_scenes)
+        )
+        await async_create_repair_issue_empty_attributes(hass, empty_attr_scenes)
+
+
+class StatefulScenesRepairFlow(RepairsFlow):
+    """Handler for repairing issues."""
+
+    def __init__(self, scene_path: str, repair_type: str) -> None:
+        """Initialize the repair flow."""
+        super().__init__()
+        self._scene_path = scene_path
+        self._repair_type = repair_type
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Start the repair flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Confirm repair action."""
+        if user_input is not None:
+            from .scene_repair_service import (
+                async_fix_duplicate_scene_ids,
+                async_cleanup_empty_attributes,
+            )
+
+            if self._repair_type == REPAIR_DUPLICATE_SCENE_IDS:
+                await async_fix_duplicate_scene_ids(self.hass, self._scene_path)
+            elif self._repair_type == REPAIR_EMPTY_SCENE_ATTRIBUTES:
+                await async_cleanup_empty_attributes(self.hass, self._scene_path)
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders=self.handler.translation_placeholders,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, Any] | None,
+) -> RepairsFlow:
+    """Return a repair flow for an issue."""
+    scene_path = data.get("scene_path") if data else None
+    if issue_id == REPAIR_DUPLICATE_SCENE_IDS:
+        return StatefulScenesRepairFlow(scene_path, REPAIR_DUPLICATE_SCENE_IDS)
+    if issue_id == REPAIR_EMPTY_SCENE_ATTRIBUTES:
+        return StatefulScenesRepairFlow(scene_path, REPAIR_EMPTY_SCENE_ATTRIBUTES)
+    raise ValueError(f"Unknown repair issue {issue_id}")
+
+
+def async_register_repairs(hass: HomeAssistant, scene_path: str) -> None:
+    """Register fix flow with Home Assistant."""
+    async_register(hass, DOMAIN, async_create_fix_flow)
+

--- a/custom_components/stateful_scenes/scene_repair_service.py
+++ b/custom_components/stateful_scenes/scene_repair_service.py
@@ -1,0 +1,101 @@
+"""Repair services for Stateful Scenes."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+import aiofiles
+import aiofiles.os as aioos
+import yaml
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .repairs import detect_duplicate_scene_ids, detect_empty_scene_attributes
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _backup_file(path: str) -> str:
+    """Create a timestamped backup of a file and return backup path."""
+    directory = os.path.dirname(path)
+    base = os.path.basename(path)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_path = os.path.join(directory, f"{base}.backup_{timestamp}")
+    try:
+        async with aiofiles.open(path, encoding="utf-8") as src, aiofiles.open(
+            backup_path, "w", encoding="utf-8"
+        ) as dst:
+            await dst.write(await src.read())
+    except OSError as err:
+        _LOGGER.error("Failed to create backup for %s: %s", path, err)
+        raise
+    return backup_path
+
+
+async def async_fix_duplicate_scene_ids(hass: HomeAssistant, scene_path: str) -> None:
+    """Fix duplicate scene IDs by generating unique ones."""
+    async with aiofiles.open(scene_path, encoding="utf-8") as f:
+        scenes = yaml.load(await f.read(), Loader=yaml.FullLoader)
+
+    duplicates = detect_duplicate_scene_ids(scenes)
+    if not duplicates:
+        return
+
+    backup = await _backup_file(scene_path)
+
+    used_ids = set()
+    for scene in scenes:
+        scene_id = scene.get("id", "")
+        if scene_id in used_ids:
+            new_id = f"{scene_id}_{datetime.now().timestamp():.0f}"
+            scene["id"] = new_id
+        used_ids.add(scene["id"])
+
+    async with aiofiles.open(scene_path, "w", encoding="utf-8") as f:
+        await f.write(yaml.dump(scenes))
+
+    try:
+        async with aiofiles.open(scene_path, encoding="utf-8") as f_verify:
+            yaml.load(await f_verify.read(), Loader=yaml.FullLoader)
+    except yaml.YAMLError as err:
+        _LOGGER.error("Repair produced invalid YAML: %s", err)
+        await aioos.replace(backup, scene_path)
+        raise
+
+    hass.async_create_task(hass.config_entries.async_reload(DOMAIN))
+
+
+async def async_cleanup_empty_attributes(hass: HomeAssistant, scene_path: str) -> None:
+    """Remove empty attributes from scenes."""
+    async with aiofiles.open(scene_path, encoding="utf-8") as f:
+        scenes = yaml.load(await f.read(), Loader=yaml.FullLoader)
+
+    affected = detect_empty_scene_attributes(scenes)
+    if not affected:
+        return
+
+    backup = await _backup_file(scene_path)
+
+    for scene in scenes:
+        for _entity, attrs in list(scene.get("entities", {}).items()):
+            for attr, value in list(attrs.items()):
+                if value is None or value == "":
+                    del attrs[attr]
+
+    async with aiofiles.open(scene_path, "w", encoding="utf-8") as f:
+        await f.write(yaml.dump(scenes))
+
+    try:
+        async with aiofiles.open(scene_path, encoding="utf-8") as f_verify:
+            yaml.load(await f_verify.read(), Loader=yaml.FullLoader)
+    except yaml.YAMLError as err:
+        _LOGGER.error("Cleanup produced invalid YAML: %s", err)
+        await aioos.replace(backup, scene_path)
+        raise
+
+    hass.async_create_task(hass.config_entries.async_reload(DOMAIN))
+
+

--- a/custom_components/stateful_scenes/translations/en.json
+++ b/custom_components/stateful_scenes/translations/en.json
@@ -49,5 +49,27 @@
             "no_entity_id": "No entity ID found",
             "hub_not_found": "Main entry not found, configure Stateful Scenes first"
         }
+    },
+    "issues": {
+        "duplicate_scene_ids": {
+            "title": "Duplicate Scene IDs Found",
+            "description": "Stateful Scenes detected {scene_count} scenes with duplicate IDs.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Fix Duplicate Scene IDs",
+                    "description": "Assign new unique IDs to scenes with duplicates."
+                }
+            }
+        },
+        "empty_scene_attributes": {
+            "title": "Empty Scene Attributes Detected",
+            "description": "Stateful Scenes found {scene_count} scenes with empty attributes.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Clean Empty Scene Attributes",
+                    "description": "Remove attributes that have no value."
+                }
+            }
+        }
     }
 }

--- a/custom_components/stateful_scenes/translations/nl.json
+++ b/custom_components/stateful_scenes/translations/nl.json
@@ -48,5 +48,27 @@
             "no_entity_id": "Geen entiteit ID gevonden",
             "hub_not_found": "Hoofd integratie niet gevonden, configureer eerst Stateful Scenes"
         }
+    },
+    "issues": {
+        "duplicate_scene_ids": {
+            "title": "Dubbele scène-ID's gevonden",
+            "description": "{scene_count} scènes hebben dezelfde ID.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Dubbele ID's oplossen",
+                    "description": "Wijs nieuwe unieke ID's toe aan scènes met duplicaten."
+                }
+            }
+        },
+        "empty_scene_attributes": {
+            "title": "Lege scène attributen gedetecteerd",
+            "description": "{scene_count} scènes bevatten lege attributen.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Lege attributen opschonen",
+                    "description": "Verwijder attributen zonder waarde."
+                }
+            }
+        }
     }
 }

--- a/custom_components/stateful_scenes/translations/sk.json
+++ b/custom_components/stateful_scenes/translations/sk.json
@@ -49,5 +49,27 @@
             "no_entity_id": "ID entity nenájdená",
             "hub_not_found": "Hlavná položka sa nenašla, najskôr nakonfigurujte stavové scény"
         }
+    },
+    "issues": {
+        "duplicate_scene_ids": {
+            "title": "Nájdené duplicitné ID scén",
+            "description": "{scene_count} scén má rovnaké ID.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Opraviť duplicitné ID scén",
+                    "description": "Priradiť nové jedinečné ID scénam s duplikátmi."
+                }
+            }
+        },
+        "empty_scene_attributes": {
+            "title": "Nájdené prázdne atribúty scény",
+            "description": "{scene_count} scén obsahuje prázdne atribúty.\n{scene_list}",
+            "fix_flow": {
+                "confirm": {
+                    "title": "Vyčistiť prázdne atribúty",
+                    "description": "Odstrániť atribúty bez hodnoty."
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add detection for duplicate and empty scene attribute issues
- implement fix flows and runtime unique IDs
- register repair flows during setup
- bump version to 1.7.3
- update translations and changelog
- add error handling and YAML validation for repair services
- fix asynchronous calls and translation schema

## Testing
- `ruff check .`
- `hassfest` *(fails: Command not found or dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_687946f5155c83269e1cbe41b22a792c